### PR TITLE
Upgrade to weewx 4

### DIFF
--- a/bin/user/interceptor.py
+++ b/bin/user/interceptor.py
@@ -251,59 +251,38 @@ the WSView app.
 # FIXME: add code to skip duplicate and out-of-order packets
 # FIXME: default acurite mapping confuses multiple tower sensors
 
-from __future__ import with_statement
-
-# support both python2 and python3.  attempt the python3 import first, then
-# fallback to python2.
-try:
-    from http.server import BaseHTTPRequestHandler
-    from socketserver import TCPServer
-    import queue as Queue
-    import urllib.parse as urlparse
-except ImportError:
-    from BaseHTTPServer import BaseHTTPRequestHandler
-    from SocketServer import TCPServer
-    import Queue
-    import urlparse
+from http.server import BaseHTTPRequestHandler
+from socketserver import TCPServer
+import queue as Queue
+import urllib.parse as urlparse
 
 import binascii
 import calendar
 import fnmatch
 import re
 import string
-import sys
 import threading
 import time
 
-try:
-    # weewx4 logging
-    import weeutil.logger
-    import logging
-    log = logging.getLogger(__name__)
-    def logdbg(msg):
-        log.debug(msg)
-    def loginf(msg):
-        log.info(msg)
-    def logerr(msg):
-        log.error(msg)
-except ImportError:
-    # old-style weewx logging
-    import syslog
-    def logmsg(level, msg):
-        syslog.syslog(level, 'interceptor: %s: %s' %
-                      (threading.currentThread().getName(), msg))
-    def logdbg(msg):
-        logmsg(syslog.LOG_DEBUG, msg)
-    def loginf(msg):
-        logmsg(syslog.LOG_INFO, msg)
-    def logerr(msg):
-        logmsg(syslog.LOG_ERR, msg)
+import logging
+import weeutil.logger
+
+log = logging.getLogger(__name__)
+
+def logdbg(msg):
+    log.debug(msg)
+
+def loginf(msg):
+    log.info(msg)
+
+def logerr(msg):
+    log.error(msg)
 
 import weewx.drivers
 import weeutil.weeutil
 
 DRIVER_NAME = 'Interceptor'
-DRIVER_VERSION = '0.60'
+DRIVER_VERSION = '0.61'
 
 DEFAULT_ADDR = ''
 DEFAULT_PORT = 80
@@ -320,14 +299,12 @@ def confeditor_loader():
 
 
 def _to_bytes(data):
-    if sys.version_info < (3, 0):
-        return bytes(data)
-    return bytes(data, 'utf8')
+    """Return a bytes representation without altering byte values."""
+    return data.encode('latin1')
 
 def _bytes_to_str(data):
-    if sys.version_info < (3, 0):
-        return data
-    return str(data, 'utf-8')
+    """Return a string representation of bytes without decoding."""
+    return data.decode('latin1')
 
 def _obfuscate_passwords(msg):
     return re.sub(r'(PASSWORD|PASSKEY)=[^&]+', r'\1=XXXX', msg)
@@ -335,7 +312,9 @@ def _obfuscate_passwords(msg):
 def _fmt_bytes(data):
     if not data:
         return ''
-    return ' '.join(['%02x' % ord(x) for x in data])
+    if isinstance(data, str):
+        data = data.encode('latin1')
+    return ' '.join('%02x' % b for b in data)
 
 def _cgi_to_dict(s):
     if '=' in s:
@@ -1890,7 +1869,7 @@ class GW1000U(Consumer):
     @staticmethod
     def encode_serial(sn):
         # encode a 16-character serial number into 8 bytes
-        return _bytes_to_str(binascii.unhexlify(sn))
+        return binascii.unhexlify(sn).decode('latin1')
 
     @staticmethod
     def encode_bcd(x):

--- a/changelog
+++ b/changelog
@@ -1,3 +1,7 @@
+0.61 01jan2024
+* require weewx v4 and python3
+* removed legacy python2 compatibility
+
 0.54 22feb2020
 * added wh40batt in ecowitt protocol
 

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class InterceptorInstaller(ExtensionInstaller):
     def __init__(self):
         super(InterceptorInstaller, self).__init__(
-            version="0.60",
+            version="0.61",
             name='interceptor',
             description='Capture weather data from HTTP requests',
             author="Matthew Wall",

--- a/readme
+++ b/readme
@@ -1,6 +1,7 @@
 weewx-interceptor
 Copyright 2016-2020 Matthew Wall
 Distributed under terms of the GPLv3
+Requires weewx 4 (Python 3)
 
 This is a driver for weewx that receives and parses network traffic.  It can
 be used with a variety of "internet bridge" devices including:
@@ -78,7 +79,7 @@ or using apt-get on debian systems:
 ===============================================================================
 Installation
 
-0) install weewx, select 'Simulator' driver
+0) install weewx 4, select 'Simulator' driver
 
 http://weewx.com/docs/usersguide.htm#installing
 


### PR DESCRIPTION
## Summary
- drop python2 compatibility
- require weewx v4 (python3)
- bump version to 0.61

## Testing
- `python3 -m py_compile bin/user/interceptor.py`

------
https://chatgpt.com/codex/tasks/task_e_6847b7015d4c8333b8859f2afd91d94e